### PR TITLE
Issue 390

### DIFF
--- a/developers.rst
+++ b/developers.rst
@@ -22,6 +22,199 @@ This file is encoded in UTF-8.  If the usual form for a name is not in
 a Latin or extended Latin alphabet, make sure to include an ASCII
 transliteration too.
 
+Active core developers
+----------------------
+
+* 2018
+  + Pablo Galindo Salgado
+  + Mark Shannon
+  + Petr Viktorin
+  + Nathaniel J. Smith
+
+* 2017
+  + Julien Palard
+  + Ivan Levkivskyi
+  + Carol Willing
+  + Mariatta Wijaya
+
+* 2016
+  + Maciej Szulik
+  + Xiang Zhang
+  + INADA Naoki
+  + Xavier de Gaye
+  + Davin Potts
+
+* 2015
+  + Martin Panter
+  + Paul Moore
+
+* 2014
+  + Chris Angelico
+  + Santoso Wijaya
+  + Stefan Richthofer
+  + Robert Collins
+  + Darjus Loktevic
+  + Berker Peksağ
+  + Steve Dower
+  + Kushal Das
+  + Steven d'Aprano
+  + Yury Selivanov
+
+* 2013
+  + Zachary Ware
+  + Donald Stufft
+  + Ethan Furman
+  + Roger Serwy
+
+* 2012
+  + Serhiy Storchaka
+  + Chris Jerdonek
+  + Daniel Holth
+  + Eric Snow
+  + Jeff Allen
+  + Peter Moody
+  + Hynek Schlawack
+  + Richard Oudkerk
+  + Andrew Svetlov
+
+* 2011
+  + Petri Lehtinen
+  + Meador Inge
+  + Sandro Tosi
+  + Charles-François Natali
+  + Nadeem Vawda
+  + Carl Friedrich Bolz
+  + Alexis Métaireau
+  + Elson Rodriguez
+  + Kelsey Hightower
+  + Michael Mulich
+  + Walker Hale
+  + Jeff Hardy
+  + Alex Gaynor
+  + Maciej Fijalkowski
+  + Ross Lagerwall
+  + Eli Bendersky
+  + Ned Deily
+
+* 2010
+  + David Malcolm
+  + Tal Einat
+  + Łukasz Langa
+  + Daniel Stutzbach
+  + Ask Solem
+  + George Boutsioukis
+  + Éric Araujo
+  + Terry Reedy
+  + Brian Quinlan
+  + Reid Kleckner
+  + Alexander Belopolsky
+  + Tim Golden
+  + Giampaolo Rodolà
+  + Jean-Paul Calderone
+  + Brian Curtin
+  + Florent Xicluna
+  + Dino Viehland
+  + Larry Hastings
+  + Victor Stinner
+  + Stefan Krah
+
+* 2009
+  + Doug Hellmann
+  + Ezio Melotti
+  + Paul Kippes
+  + Ron DuPlain
+  + R. David Murray
+  + Chris Withers
+
+* 2008
+  + Tarek Ziadé
+  + Hirokazu Yamamoto
+  + Antoine Pitrou
+  + Jesse Noller
+  + Gregor Lingl
+  + Robert Schuppenies
+  + Rodrigo Bernardo Pimentel
+  + Heiko Weinen
+  + Jesús Cea
+  + Guilherme Polo
+  + Thomas Lee
+  + Jeroen Ruigrok van der Werven
+  + Josiah Carlson
+  + Benjamin Peterson
+  + Jerry Seutter
+  + Jeff Rush
+  + David Wolever
+  + Trent Nelson
+  + Mark Dickinson
+
+* 2007
+  + Amaury Forgeot d'Arc
+  + Christian Heimes
+  + Chris Monson
+  + Bill Janssen
+  + Jeffrey Yasskin
+  + Mark Summerfield
+  + Armin Ronacher
+  + Senthil Kumaran
+  + Alexandre Vassalotti
+  + Travis Oliphant
+  + Ziga Seilnacht
+  + Pete Shinners
+  + Pat Maupin
+  + Eric V. Smith
+  + Steven Bethard
+  + Josiah Carlson
+  + Collin Winter
+
+* 2006
+  + Lars Gustaebel
+  + Matt Fleming
+  + Jackilyn Hoxworth
+  + Mateusz Rukowicz
+  + Steven Bethard
+  + Talin
+  + George Yoshida
+  + Ronald Oussoren
+  + Bob Ippolito
+
+* 2005
+  + Gregory K Johnson
+  + Floris Bruynooghe
+  + Georg Brandl
+  + Terry Reedy
+  + Nick Coghlan
+
+* 2003
+  + Armin Rigo
+  + Eric Price
+
+* 2000
+  + Eric S. Raymond
+
+- Several developers of alternative Python implementations where
+  given access for test suite and library adaptions by MvL:
+  Allison Randal (Parrot), Michael Foord (IronPython),
+  Jim Baker, Philip Jenvey, and Frank Wierzbicki (all Jython).
+
+
+- SVN access granted to the "Need for Speed" Iceland sprint attendees,
+  between May 17 and 21, 2006, by Tim Peters.  All work is to be done
+  in new sandbox projects or on new branches, with merging to the
+  trunk as approved:
+
+  Andrew Dalke
+  Christian Tismer
+  Jack Diederich
+  John Benediktsson
+  Kristján V. Jónsson
+  Martin Blais
+  Richard Emslie
+  Richard Jones
+  Runar Petursson
+  Steve Holden
+  Richard M. Tew
+
+
 Permissions History
 -------------------
 

--- a/developers.rst
+++ b/developers.rst
@@ -26,18 +26,21 @@ Active core developers
 ----------------------
 
 * 2018
+
   + Pablo Galindo Salgado
   + Mark Shannon
   + Petr Viktorin
   + Nathaniel J. Smith
 
 * 2017
+
   + Julien Palard
   + Ivan Levkivskyi
   + Carol Willing
   + Mariatta Wijaya
 
 * 2016
+
   + Maciej Szulik
   + Xiang Zhang
   + INADA Naoki
@@ -45,10 +48,12 @@ Active core developers
   + Davin Potts
 
 * 2015
+
   + Martin Panter
   + Paul Moore
 
 * 2014
+
   + Chris Angelico
   + Santoso Wijaya
   + Stefan Richthofer
@@ -61,12 +66,14 @@ Active core developers
   + Yury Selivanov
 
 * 2013
+
   + Zachary Ware
   + Donald Stufft
   + Ethan Furman
   + Roger Serwy
 
 * 2012
+
   + Serhiy Storchaka
   + Chris Jerdonek
   + Daniel Holth
@@ -78,6 +85,7 @@ Active core developers
   + Andrew Svetlov
 
 * 2011
+
   + Petri Lehtinen
   + Meador Inge
   + Sandro Tosi
@@ -97,6 +105,7 @@ Active core developers
   + Ned Deily
 
 * 2010
+
   + David Malcolm
   + Tal Einat
   + Łukasz Langa
@@ -119,6 +128,7 @@ Active core developers
   + Stefan Krah
 
 * 2009
+
   + Doug Hellmann
   + Ezio Melotti
   + Paul Kippes
@@ -127,6 +137,7 @@ Active core developers
   + Chris Withers
 
 * 2008
+
   + Tarek Ziadé
   + Hirokazu Yamamoto
   + Antoine Pitrou
@@ -148,6 +159,7 @@ Active core developers
   + Mark Dickinson
 
 * 2007
+
   + Amaury Forgeot d'Arc
   + Christian Heimes
   + Chris Monson
@@ -167,6 +179,7 @@ Active core developers
   + Collin Winter
 
 * 2006
+  
   + Lars Gustaebel
   + Matt Fleming
   + Jackilyn Hoxworth
@@ -178,6 +191,7 @@ Active core developers
   + Bob Ippolito
 
 * 2005
+  
   + Gregory K Johnson
   + Floris Bruynooghe
   + Georg Brandl
@@ -185,17 +199,18 @@ Active core developers
   + Nick Coghlan
 
 * 2003
+
   + Armin Rigo
   + Eric Price
 
 * 2000
+
   + Eric S. Raymond
 
 - Several developers of alternative Python implementations where
   given access for test suite and library adaptions by MvL:
   Allison Randal (Parrot), Michael Foord (IronPython),
   Jim Baker, Philip Jenvey, and Frank Wierzbicki (all Jython).
-
 
 - SVN access granted to the "Need for Speed" Iceland sprint attendees,
   between May 17 and 21, 2006, by Tim Peters.  All work is to be done
@@ -213,7 +228,6 @@ Active core developers
   Runar Petursson
   Steve Holden
   Richard M. Tew
-
 
 Permissions History
 -------------------


### PR DESCRIPTION
`@@ -2,26 +2,233 @@
 
 Developer Log
 =============
 
 This file is a running log of developers given commit privileges for Python.
 
 The purpose is to provide some institutional memory of who was given access
 and why.
 
 The first entry starts in April 2005.  Newer entries should be added to the top.
 Entries should include the name or initials of the project admin who made the
 change or granted access.  The procedure for adding or removing users is
 described in :ref:`altering-access`.
 
 Note, when giving new commit permissions, be sure to get a contributor agreement
 from the committer.  See https://www.python.org/psf/contrib/ for details.
 Commit privileges should not be given until the contributor agreement has been
 signed and received.
 
 This file is encoded in UTF-8.  If the usual form for a name is not in
a Latin or extended Latin alphabet, make sure to include an ASCII
transliteration too.
 Active core developers
----------------------
 * 2018
   + Pablo Galindo Salgado
  + Mark Shannon
  + Petr Viktorin
  + Nathaniel J. Smith
 * 2017
   + Julien Palard
  + Ivan Levkivskyi
  + Carol Willing
  + Mariatta Wijaya
 * 2016
   + Maciej Szulik
  + Xiang Zhang
  + INADA Naoki
  + Xavier de Gaye
  + Davin Potts
 * 2015
   + Martin Panter
  + Paul Moore
 * 2014
   + Chris Angelico
  + Santoso Wijaya
  + Stefan Richthofer
  + Robert Collins
  + Darjus Loktevic
  + Berker Peksağ
  + Steve Dower
  + Kushal Das
  + Steven d'Aprano
  + Yury Selivanov
 * 2013
   + Zachary Ware
  + Donald Stufft
  + Ethan Furman
  + Roger Serwy
 * 2012
   + Serhiy Storchaka
  + Chris Jerdonek
  + Daniel Holth
  + Eric Snow
  + Jeff Allen
  + Peter Moody
  + Hynek Schlawack
  + Richard Oudkerk
  + Andrew Svetlov
 * 2011
   + Petri Lehtinen
  + Meador Inge
  + Sandro Tosi
  + Charles-François Natali
  + Nadeem Vawda
  + Carl Friedrich Bolz
  + Alexis Métaireau
  + Elson Rodriguez
  + Kelsey Hightower
  + Michael Mulich
  + Walker Hale
  + Jeff Hardy
  + Alex Gaynor
  + Maciej Fijalkowski
  + Ross Lagerwall
  + Eli Bendersky
  + Ned Deily
 * 2010
   + David Malcolm
  + Tal Einat
  + Łukasz Langa
  + Daniel Stutzbach
  + Ask Solem
  + George Boutsioukis
  + Éric Araujo
  + Terry Reedy
  + Brian Quinlan
  + Reid Kleckner
  + Alexander Belopolsky
  + Tim Golden
  + Giampaolo Rodolà
  + Jean-Paul Calderone
  + Brian Curtin
  + Florent Xicluna
  + Dino Viehland
  + Larry Hastings
  + Victor Stinner
  + Stefan Krah
 * 2009
   + Doug Hellmann
  + Ezio Melotti
  + Paul Kippes
  + Ron DuPlain
  + R. David Murray
  + Chris Withers
 * 2008
   + Tarek Ziadé
  + Hirokazu Yamamoto
  + Antoine Pitrou
  + Jesse Noller
  + Gregor Lingl
  + Robert Schuppenies
  + Rodrigo Bernardo Pimentel
  + Heiko Weinen
  + Jesús Cea
  + Guilherme Polo
  + Thomas Lee
  + Jeroen Ruigrok van der Werven
  + Josiah Carlson
  + Benjamin Peterson
  + Jerry Seutter
  + Jeff Rush
  + David Wolever
  + Trent Nelson
  + Mark Dickinson
 * 2007
   + Amaury Forgeot d'Arc
  + Christian Heimes
  + Chris Monson
  + Bill Janssen
  + Jeffrey Yasskin
  + Mark Summerfield
  + Armin Ronacher
  + Senthil Kumaran
  + Alexandre Vassalotti
  + Travis Oliphant
  + Ziga Seilnacht
  + Pete Shinners
  + Pat Maupin
  + Eric V. Smith
  + Steven Bethard
  + Josiah Carlson
  + Collin Winter
 * 2006
  
  + Lars Gustaebel
  + Matt Fleming
  + Jackilyn Hoxworth
  + Mateusz Rukowicz
  + Steven Bethard
  + Talin
  + George Yoshida
  + Ronald Oussoren
  + Bob Ippolito
 * 2005
  
  + Gregory K Johnson
  + Floris Bruynooghe
  + Georg Brandl
  + Terry Reedy
  + Nick Coghlan
 * 2003
   + Armin Rigo
  + Eric Price
 * 2000
   + Eric S. Raymond
 - Several developers of alternative Python implementations where
  given access for test suite and library adaptions by MvL:
  Allison Randal (Parrot), Michael Foord (IronPython),
  Jim Baker, Philip Jenvey, and Frank Wierzbicki (all Jython).
 - SVN access granted to the "Need for Speed" Iceland sprint attendees,
  between May 17 and 21, 2006, by Tim Peters.  All work is to be done
  in new sandbox projects or on new branches, with merging to the
  trunk as approved:
   Andrew Dalke
  Christian Tismer
  Jack Diederich
  John Benediktsson
  Kristján V. Jónsson
  Martin Blais
  Richard Emslie
  Richard Jones
  Runar Petursson
  Steve Holden
  Richard M. Tew
 Permissions History
-------------------
`