### PR TITLE
Update developers.rst

### DIFF
--- a/developers.rst
+++ b/developers.rst
@@ -413,7 +413,7 @@ Permissions History
 
 - Added two new developers for the Summer of Code project. 8 July 2005
   by RDH.  Andrew Kuchling will be mentoring Gregory K Johnson for a
-  project to enhance mailbox.  Brett Cannon requested access for Flovis
+  project to enhance mailbox.  Brett Cannon requested access for Floris
   Bruynooghe (sirolf) to work on pstats, profile, and hotshot.  Both users
   are expected to work primarily in nondist/sandbox and have their work
   reviewed before making updates to active code.
@@ -468,7 +468,7 @@ Permissions Dropped on Request
 
 - Johannes Gijsbers sent a drop request.  27 July 2005 RDH
 
-- Flovis Bruynooghe sent a drop request.  14 July 2005 RDH
+- Floris Bruynooghe sent a drop request.  14 July 2005 RDH
 
 - Paul Prescod sent a drop request.  30 Apr 2005 RDH
 


### PR DESCRIPTION
`
 @@ -393,27 +393,27 @@
 
 - Steven Bethard was given SVN access on 27 Apr 2006 by DJG, for PEP
   update access.
 
 - Talin was given SVN access on 27 Apr 2006 by DJG, for PEP update
   access.
 
 - George Yoshida (SF name "quiver") added to the SourceForge Python
   project 14 Apr 2006, by Tim Peters, as a tracker admin.  See
   contemporaneous python-checkins thread with the unlikely Subject:
   r45329 - python/trunk/Doc/whatsnew/whatsnew25.tex
 
 - Ronald Oussoren was given SVN access on 3 Mar 2006 by NCN, for Mac
   related work.
 
 - Bob Ippolito was given SVN access on 2 Mar 2006 by NCN, for Mac
   related work.
 
 - Nick Coghlan requested CVS access so he could update his PEP directly.
   Granted by GvR on 16 Oct 2005.
 - Added two new developers for the Summer of Code project. 8 July 2005
  by RDH.  Andrew Kuchling will be mentoring Gregory K Johnson for a
  project to enhance mailbox.  Brett Cannon requested access for Flovis
  project to enhance mailbox.  Brett Cannon requested access for Floris
  Bruynooghe (sirolf) to work on pstats, profile, and hotshot.  Both users
  are expected to work primarily in nondist/sandbox and have their work
  reviewed before making updates to active code.
 @@ -448,27 +448,27 @@
 - Xavier de Gaye's privileges were dropped on 25 January 2018 by Brett Cannon
   per his `request <https://mail.python.org/pipermail/python-committers/2018-January/005163.html>`_.
 
 - Andrew MacIntyre's privileges were dropped on 2 January 2016 by BCP per his
   request.
 
 - Skip Montanaro's permissions were removed on 21 April 2015 by BCP per `his
   request <https://bugs.python.org/msg241740>`_.
 
 - Armin Rigo permissions were removed on 2012.
 
 - Roy Smith, Matt Fleming and Richard Emslie sent drop requests.
   4 Aug 2008 GFB
 
 - Per note from Andrew Kuchling, the permissions for Gregory K Johnson
   and the Summer Of Code project are no longer needed.  4 Aug 2008 GFB
 
 - Per note from Andrew Kuchling, the permissions for Gregory K Johnson
   and the Summer Of Code project are no longer needed.  AMK will make
   any future checkins directly.  16 Oct 2005 RDH
 - Johannes Gijsbers sent a drop request.  27 July 2005 RDH
 - Flovis Bruynooghe sent a drop request.  14 July 2005 RDH
- Floris Bruynooghe sent a drop request.  14 July 2005 RDH
 - Paul Prescod sent a drop request.  30 Apr 2005 RDH
  - Finn Bock sent a drop request.  13 Apr 2005 RDH
 
 - Eric Price sent a drop request.  10 Apr 2005 RDH
 
 - Irmen de Jong requested dropping CVS access while keeping tracker
   access.  10 Apr 2005 RDH
 
 - Moshe Zadka and Ken Manheimer sent drop requests.  8 Apr 2005 by RDH
 
 - Steve Holden, Gerhard Haring, and David Cole sent email stating that
   they no longer use their access.   7 Apr 2005 RDH
 
 
 Permissions Dropped after Loss of Contact
 -----------------------------------------
 
 - Several unsuccessful efforts were made to contact Charles G Waldman.
   Removed on 8 Apr 2005 by RDH.
 
 `